### PR TITLE
fix(cache): add isNode check on adding a response to the cache

### DIFF
--- a/Client/shared/cache/api.ts
+++ b/Client/shared/cache/api.ts
@@ -1,6 +1,7 @@
 ﻿import { Injectable } from '@angular/core';
 import { Http, RequestOptionsArgs } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
+import { isNode } from 'angular2-universal';
 
 import 'rxjs/add/observable/throw';
 import 'rxjs/add/observable/of';
@@ -41,7 +42,7 @@ export class HttpCacheService {
 
         return this._http.get(url, options)
             .map(res => res.json())
-            .do(json => { this._cache.set(key, json); })
+            .do(json => { if (isNode) { this._cache.set(key, json); } })
             .share();
     }
 }


### PR DESCRIPTION

We need to cache requests’ responses and pass them to the client on the
server only. We do not need to cache client’s requests. So adding isNode
check when we save a response to the cache.

Fix for https://github.com/MarkPieszak/aspnetcore-angular2-universal/issues/74.