### PR TITLE
Fix typo in comment sample in vendor webpack.

### DIFF
--- a/webpack.config.vendor.js
+++ b/webpack.config.vendor.js
@@ -71,7 +71,7 @@ module.exports = (env) => {
             new webpack.IgnorePlugin(/^vertx$/) // Workaround for https://github.com/stefanpenner/es6-promise/issues/100
 
         ]
-        // .concat(isDevelopment ? [] : [
+        // .concat(isDevBuild ? [] : [
         //     new webpack.optimize.UglifyJsPlugin({ compress: { warnings: false } })
         // ])
     };


### PR DESCRIPTION
At some point it seams the const `isDevBuild` used to be `isDevelopment`. A comment of an example was still using the old const.