### PR TITLE
removing awesome-typescript-loader forkcheckerplugin usage from webpack configs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -159,8 +159,6 @@ module.exports = (env) => {
                 tsconfig: 'tsconfig.json'
             }),
 
-            // new ForkCheckerPlugin(),
-
             new webpack.DllReferencePlugin({
                 context: __dirname,
                 manifest: require('./wwwroot/dist/vendor-manifest.json')

--- a/webpack.config.test.js
+++ b/webpack.config.test.js
@@ -11,7 +11,6 @@ var clone = require('js.clone');
 // & create the modules correctly
 var ContextReplacementPlugin = require('webpack/lib/ContextReplacementPlugin');
 var TsConfigPathsPlugin = require('awesome-typescript-loader').TsConfigPathsPlugin;
-var ForkCheckerPlugin = require('awesome-typescript-loader').ForkCheckerPlugin;
 var DefinePlugin = require('webpack/lib/DefinePlugin');
 
 // Test if Development build from ASPNETCore environment
@@ -120,8 +119,6 @@ module.exports = setTypeScriptAlias(require('./tsconfig.json'), {
         new TsConfigPathsPlugin({
             tsconfig: 'tsconfig.json'
         }),
-
-        new ForkCheckerPlugin(),
 
         new webpack.DllReferencePlugin({
             context: '.',


### PR DESCRIPTION
remove the forkcheckerplugin that is no longer needed for awesome-typescript-loader.  This is regarding bug https://github.com/MarkPieszak/aspnetcore-angular2-universal/issues/93