### PR TITLE
Enabling Echo on CMD

### DIFF
--- a/src/AspCoreServer/prepublish.cmd
+++ b/src/AspCoreServer/prepublish.cmd
@@ -1,4 +1,3 @@
-@echo off
 pushd
 cd %~dp0..\Angular2Spa
 npm install


### PR DESCRIPTION
Echo is enabled so that if any error in CMD, that can be seen easily