### PR TITLE
Fix WebPack warning "There are multiple modules with names that only …

### DIFF
--- a/Client/polyfills/rx-imports.ts
+++ b/Client/polyfills/rx-imports.ts
@@ -6,11 +6,11 @@
  */
 
 // Observable
-import 'rxjs/Observable';
-import 'rxjs/Observable/throw';
+import 'rxjs/observable';
+import 'rxjs/observable/throw';
 
 // Subject
-import 'rxjs/Subject';
+import 'rxjs/subject';
 
 // Operators
 import 'rxjs/add/operator/filter';


### PR DESCRIPTION
Fix WebPack warning "There are multiple modules with names that only …  …
…differ in casing. This can lead to unexpected behavior when compiling on a filesystem with other case-semantic." on Windows machines.