### PR TITLE
feat(engine): update engine & add transfer mechanism

### DIFF
--- a/Client/app/app.component.ts
+++ b/Client/app/app.component.ts
@@ -7,6 +7,7 @@ import { LinkService } from './shared/link.service';
 
 // i18n support
 import { TranslateService } from '@ngx-translate/core';
+import { REQUEST } from './shared/constants/request';
 
 @Component({
     selector: 'app',
@@ -29,13 +30,18 @@ export class AppComponent implements OnInit, OnDestroy {
         private title: Title,
         private meta: Meta,
         private linkService: LinkService,
-        public translate: TranslateService
+        public translate: TranslateService,
+        @Inject(REQUEST) private request
     ) {
         // this language will be used as a fallback when a translation isn't found in the current language
         translate.setDefaultLang('en');
 
         // the lang to use, if the lang isn't available, it will use the current loader to get them
         translate.use('en');
+
+        console.log(`What's our REQUEST Object look like?`);
+        console.log(`The Request object only really exists on the Server, but on the Browser we can at least see Cookies`);
+        console.log(this.request);
     }
 
     ngOnInit() {

--- a/Client/app/app.module.ts
+++ b/Client/app/app.module.ts
@@ -21,9 +21,9 @@ import { Ng2BootstrapComponent } from './containers/ng2-bootstrap-demo/ng2bootst
 import { LinkService } from './shared/link.service';
 import { ConnectionResolver } from './shared/route.resolver';
 import { ORIGIN_URL } from './shared/constants/baseurl.constants';
+import { TransferHttpModule } from '../modules/transfer-http/transfer-http.module';
 
 export function createTranslateLoader(http: Http, baseHref) {
-    console.log('\n\n\n New method? ' + baseHref);
     // Temporary Azure hack
     if (baseHref === null && typeof window !== 'undefined') {
         baseHref = window.location.origin;
@@ -41,12 +41,14 @@ export function createTranslateLoader(http: Http, baseHref) {
         HomeComponent,
         ChatComponent,
         Ng2BootstrapComponent
-    ],
+    ], 
     imports: [
         CommonModule,
         HttpModule,
         FormsModule,
         Ng2BootstrapModule.forRoot(), // You could also split this up if you don't want the Entire Module imported
+
+        TransferHttpModule, // Our Http TransferData method
 
         // i18n support
         TranslateModule.forRoot({

--- a/Client/app/browser-app.module.ts
+++ b/Client/app/browser-app.module.ts
@@ -8,6 +8,8 @@ import { SignalRModule, SignalRConfiguration } from 'ng2-signalr';
 import { ORIGIN_URL } from './shared/constants/baseurl.constants';
 import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
+import { REQUEST } from './shared/constants/request';
+import { BrowserTransferStateModule } from '../modules/transfer-state/browser-transfer-state.module';
 
 export function createConfig(): SignalRConfiguration {
     const signalRConfig = new SignalRConfiguration();
@@ -24,6 +26,11 @@ export function getOriginUrl() {
   return window.location.origin;
 }
 
+export function getRequest() {
+  // the Request object only lives on the server
+  return { cookie: document.cookie };
+}
+
 @NgModule({
     bootstrap: [AppComponent],
     imports: [
@@ -31,6 +38,8 @@ export function getOriginUrl() {
             appId: 'my-app-id' // make sure this matches with your Server NgModule
         }),
         BrowserAnimationsModule,
+        BrowserTransferStateModule,
+
         // Our Common AppModule
         AppModule,
 
@@ -38,9 +47,14 @@ export function getOriginUrl() {
     ],
     providers: [
         {
-            // We need this for our Http calls since they'll be using APP_BASE_HREF (since the Server requires Absolute URLs)
+            // We need this for our Http calls since they'll be using an ORIGIN_URL provided in main.server
+            // (Also remember the Server requires Absolute URLs)
             provide: ORIGIN_URL,
             useFactory: (getOriginUrl)
+        }, {
+            // The server provides these in main.server
+            provide: REQUEST,
+            useFactory: (getRequest)
         }
     ]
 })

--- a/Client/app/server-app.module.ts
+++ b/Client/app/server-app.module.ts
@@ -1,31 +1,34 @@
 import { NgModule } from '@angular/core';
 import { ServerModule } from '@angular/platform-server';
 import { BrowserModule } from '@angular/platform-browser';
-import { NoopAnimationsModule  } from '@angular/platform-browser/animations';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { AppModule } from './app.module';
 import { AppComponent } from './app.component';
-
+import { ServerTransferStateModule } from '../modules/transfer-state/server-transfer-state.module';
+import { TransferState } from '../modules/transfer-state/transfer-state';
 
 @NgModule({
-    bootstrap: [ AppComponent ],
-    imports: [
-        BrowserModule.withServerTransition({
-            appId: 'my-app-id' // make sure this matches with your Browser NgModule
-        }),
-        ServerModule,
-        NoopAnimationsModule,
-        
-        // Our Common AppModule
-        AppModule 
-    ]
+  bootstrap: [AppComponent],
+  imports: [
+    BrowserModule.withServerTransition({
+      appId: 'my-app-id' // make sure this matches with your Browser NgModule
+    }),
+    ServerModule,
+    NoopAnimationsModule,
+
+    ServerTransferStateModule,
+
+    // Our Common AppModule
+    AppModule
+  ]
 })
 export class ServerAppModule {
 
-    // constructor(private transferState: TransferState) { }
+  constructor(private transferState: TransferState) { }
 
-    // // Gotcha
-    // ngOnBootstrap = () => {
-    //     this.transferState.inject();
-    // }
+  // Gotcha (needs to be an arrow function)
+  ngOnBootstrap = () => {
+    this.transferState.inject();
+  }
 }

--- a/Client/app/shared/constants/request.ts
+++ b/Client/app/shared/constants/request.ts
@@ -1,0 +1,3 @@
+import { InjectionToken } from '@angular/core';
+
+export const REQUEST = new InjectionToken<string>('REQUEST');

--- a/Client/main.server.aot.ts
+++ b/Client/main.server.aot.ts
@@ -8,32 +8,33 @@ import { ORIGIN_URL } from './app/shared/constants/baseurl.constants';
 // Grab the (Node) server-specific NgModule
 import { ServerAppModuleNgFactory } from './ngfactory/app/server-app.module.ngfactory';
 // Temporary * the engine will be on npm soon (`@universal/ng-aspnetcore-engine`)
-import { ngAspnetCoreEngineAoT } from './polyfills/temporary-aspnetcore-engine';
+import { ngAspnetCoreEngine, IEngineOptions, createTransferScript } from './polyfills/temporary-aspnetcore-engine';
 
 enableProdMode();
 
 export default createServerRenderer(params => {
 
-    // Platform-server provider configuration
-    const providers = [
-        {
-            provide: INITIAL_CONFIG,
-            useValue: {
-                document: '<app></app>', // Our Root application document
-                url: params.url
-            }
-        }, {
-            provide: ORIGIN_URL,
-            useValue: params.origin
-        }
-    ];
+  // Platform-server provider configuration
+  const setupOptions: IEngineOptions = {
+    appSelector: '<app></app>',
+    ngModule: ServerAppModuleNgFactory,
+    request: params,
+    providers: [
+      // Optional - Any other Server providers you want to pass (remember you'll have to provide them for the Browser as well)
+    ]
+  };
 
-    return ngAspnetCoreEngineAoT(providers, ServerAppModuleNgFactory).then(response => {
-        return ({
-            html: response.html,
-            globals: response.globals
-        });
+  return ngAspnetCoreEngine(setupOptions).then(response => {
+    // Apply your transferData to response.globals
+    response.globals.transferData = createTransferScript({
+      someData: 'Transfer this to the client on the window.TRANSFER_CACHE {} object'
     });
+
+    return ({
+      html: response.html,
+      globals: response.globals
+    });
+  });
 });
 
 /* -------- THIS FILE IS TEMPORARY and will be gone when @ngtools/webpack can handle dual files (w server) ---------- */

--- a/Client/main.server.ts
+++ b/Client/main.server.ts
@@ -9,30 +9,32 @@ import { ORIGIN_URL } from './app/shared/constants/baseurl.constants';
 // Grab the (Node) server-specific NgModule
 import { ServerAppModule } from './app/server-app.module';
 // Temporary * the engine will be on npm soon (`@universal/ng-aspnetcore-engine`)
-import { ngAspnetCoreEngine } from './polyfills/temporary-aspnetcore-engine';
+import { ngAspnetCoreEngine, IEngineOptions, createTransferScript } from './polyfills/temporary-aspnetcore-engine';
 
 enableProdMode();
 
-export default createServerRenderer(params => {
+export default createServerRenderer((params: BootFuncParams) => {
 
-    // Platform-server provider configuration
-    const providers = [
-        {
-            provide: INITIAL_CONFIG,
-            useValue: {
-                document: '<app></app>', // Our Root application document
-                url: params.url
-            }
-        }, {
-            provide: ORIGIN_URL,
-            useValue: params.origin
-        }
-    ];
+  // Platform-server provider configuration
+  const setupOptions: IEngineOptions = {
+    appSelector: '<app></app>',
+    ngModule: ServerAppModule,
+    request: params,
+    providers: [
+      // Optional - Any other Server providers you want to pass (remember you'll have to provide them for the Browser as well)
+    ]
+  };
 
-    return ngAspnetCoreEngine(providers, ServerAppModule).then(response => {
-        return ({
-            html: response.html,
-            globals: response.globals
-        });
+  return ngAspnetCoreEngine(setupOptions).then(response => {
+    // Apply your transferData to response.globals
+    response.globals.transferData = createTransferScript({
+      someData: 'Transfer this to the client on the window.TRANSFER_CACHE {} object',
+      fromDotnet: params.data.thisCameFromDotNET // example of data coming from dotnet, in HomeController
     });
+
+    return ({
+      html: response.html,
+      globals: response.globals
+    });
+  });
 });

--- a/Client/modules/transfer-http/transfer-http.module.ts
+++ b/Client/modules/transfer-http/transfer-http.module.ts
@@ -1,0 +1,10 @@
+import { NgModule } from '@angular/core';
+import { Http, HttpModule } from '@angular/http';
+import { TransferHttp } from './transfer-http';
+
+@NgModule({
+  providers: [
+    TransferHttp
+  ]
+})
+export class TransferHttpModule {}

--- a/Client/modules/transfer-http/transfer-http.ts
+++ b/Client/modules/transfer-http/transfer-http.ts
@@ -1,0 +1,152 @@
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { ConnectionBackend, Http, Request, RequestOptions, RequestOptionsArgs, Response } from '@angular/http';
+import { Observable } from 'rxjs/Observable';
+import { Subject } from 'rxjs/Subject';
+import { TransferState } from '../transfer-state/transfer-state';
+import { isPlatformServer } from '@angular/common';
+
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/observable/fromPromise';
+
+@Injectable()
+export class TransferHttp {
+
+  private isServer = isPlatformServer(this.platformId);
+
+  constructor(
+    @Inject(PLATFORM_ID) private platformId,
+    private http: Http,
+    protected transferState: TransferState
+  ) { }
+
+  request(uri: string | Request, options?: RequestOptionsArgs): Observable<any> {
+    return this.getData(uri, options, (url: string, options: RequestOptionsArgs) => {
+      return this.http.request(url, options);
+    });
+  }
+  /**
+   * Performs a request with `get` http method.
+   */
+  get(url: string, options?: RequestOptionsArgs): Observable<any> {
+    return this.getData(url, options, (url: string, options: RequestOptionsArgs) => {
+      return this.http.get(url, options);
+    });
+  }
+  /**
+   * Performs a request with `post` http method.
+   */
+  post(url: string, body: any, options?: RequestOptionsArgs): Observable<any> {
+    return this.getPostData(url, body, options, (url: string, options: RequestOptionsArgs) => {
+      return this.http.post(url, body, options);
+    });
+  }
+  /**
+   * Performs a request with `put` http method.
+   */
+  put(url: string, body: any, options?: RequestOptionsArgs): Observable<any> {
+
+    return this.getPostData(url, body, options, (url: string, options: RequestOptionsArgs) => {
+      return this.http.put(url, body, options);
+    });
+  }
+  /**
+   * Performs a request with `delete` http method.
+   */
+  delete(url: string, options?: RequestOptionsArgs): Observable<any> {
+    return this.getData(url, options, (url: string, options: RequestOptionsArgs) => {
+      return this.http.delete(url, options);
+    });
+  }
+  /**
+   * Performs a request with `patch` http method.
+   */
+  patch(url: string, body: any, options?: RequestOptionsArgs): Observable<any> {
+    return this.getPostData(url, body, options, (url: string, options: RequestOptionsArgs) => {
+      return this.http.patch(url, body.options);
+    });
+  }
+  /**
+   * Performs a request with `head` http method.
+   */
+  head(url: string, options?: RequestOptionsArgs): Observable<any> {
+    return this.getData(url, options, (url: string, options: RequestOptionsArgs) => {
+      return this.http.head(url, options);
+    });
+  }
+  /**
+   * Performs a request with `options` http method.
+   */
+  options(url: string, options?: RequestOptionsArgs): Observable<any> {
+    return this.getData(url, options, (url: string, options: RequestOptionsArgs) => {
+      return this.http.options(url, options);
+    });
+  }
+
+  private getData(uri: string | Request, options: RequestOptionsArgs, callback: (uri: string | Request, options?: RequestOptionsArgs) => Observable<Response>) {
+
+    let url = uri;
+
+    if (typeof uri !== 'string') {
+      url = uri.url;
+    }
+
+    const key = url + JSON.stringify(options);
+
+    try {
+      return this.resolveData(key);
+
+    } catch (e) {
+      return callback(url, options)
+        .map(res => res.json())
+        .do(data => {
+          if (this.isServer) {
+            this.setCache(key, data);
+          }
+        });
+    }
+  }
+
+  private getPostData(uri: string | Request, body: any, options: RequestOptionsArgs, callback: (uri: string | Request, body: any, options?: RequestOptionsArgs) => Observable<Response>) {
+
+    let url = uri;
+
+    if (typeof uri !== 'string') {
+      url = uri.url;
+    }
+
+    const key = url + JSON.stringify(body);
+
+    try {
+
+      return this.resolveData(key);
+
+    } catch (e) {
+      return callback(uri, body, options)
+        .map(res => res.json())
+        .do(data => {
+          if (this.isServer) {
+            this.setCache(key, data);
+          }
+        });
+    }
+  }
+
+  private resolveData(key: string) {
+    const data = this.getFromCache(key);
+
+    if (!data) {
+      throw new Error();
+    }
+
+    return Observable.fromPromise(Promise.resolve(data));
+  }
+
+  private setCache(key, data) {
+    return this.transferState.set(key, data);
+  }
+
+  private getFromCache(key): any {
+    return this.transferState.get(key);
+  }
+}

--- a/Client/modules/transfer-state/browser-transfer-state.module.ts
+++ b/Client/modules/transfer-state/browser-transfer-state.module.ts
@@ -1,0 +1,20 @@
+import { NgModule, PLATFORM_ID } from '@angular/core';
+import { TransferState } from './transfer-state';
+
+export function getTransferState(): TransferState {
+  const transferState = new TransferState();
+  transferState.initialize(window['TRANSFER_STATE'] || {});
+  return transferState;
+}
+
+@NgModule({
+  providers: [
+    {
+      provide: TransferState,
+      useFactory: getTransferState
+    }
+  ]
+})
+export class BrowserTransferStateModule {
+
+}

--- a/Client/modules/transfer-state/server-transfer-state.module.ts
+++ b/Client/modules/transfer-state/server-transfer-state.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { ServerTransferState } from './server-transfer-state';
+import { TransferState } from './transfer-state';
+
+@NgModule({
+  providers: [
+    { provide: TransferState, useClass: ServerTransferState }
+  ]
+})
+export class ServerTransferStateModule {
+
+}

--- a/Client/modules/transfer-state/server-transfer-state.ts
+++ b/Client/modules/transfer-state/server-transfer-state.ts
@@ -1,0 +1,36 @@
+import { Injectable, Optional, RendererFactory2, ViewEncapsulation, Inject, PLATFORM_ID } from '@angular/core';
+import { TransferState } from './transfer-state';
+import { PlatformState } from '@angular/platform-server';
+@Injectable()
+export class ServerTransferState extends TransferState {
+  constructor(private state: PlatformState, private rendererFactory: RendererFactory2) {
+    super();
+  }
+
+  /**
+   * Inject the State into the bottom of the <head>
+   */
+  inject() {
+    try {
+      const document: any = this.state.getDocument();
+      const transferStateString = JSON.stringify(this.toJson());
+      const renderer = this.rendererFactory.createRenderer(document, {
+        id: '-1',
+        encapsulation: ViewEncapsulation.None,
+        styles: [],
+        data: {}
+      });
+
+      const body = document.body;
+
+      const script = renderer.createElement('script');
+      renderer.setValue(script, `window['TRANSFER_STATE'] = ${transferStateString}`);
+      renderer.appendChild(body, script);
+    } catch (e) {
+      console.log('Failed to append TRANSFER_STATE to body');
+      console.error(e);
+    }
+  }
+
+
+}

--- a/Client/modules/transfer-state/transfer-state.ts
+++ b/Client/modules/transfer-state/transfer-state.ts
@@ -1,0 +1,40 @@
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+
+@Injectable()
+export class TransferState {
+  private _map = new Map<string, any>();
+
+  constructor() { }
+
+  keys() {
+    return this._map.keys();
+  }
+
+  get(key: string): any {
+    const cachedValue = this._map.get(key);
+    this._map.delete(key);
+    return cachedValue;
+  }
+
+  set(key: string, value: any): Map<string, any> {
+    return this._map.set(key, value);
+  }
+
+  toJson(): any {
+    const obj = {};
+    Array.from(this.keys())
+      .forEach(key => {
+        obj[key] = this.get(key);
+      });
+    return obj;
+  }
+
+  initialize(obj: any): void {
+    Object.keys(obj)
+      .forEach(key => {
+        this.set(key, obj[key]);
+      });
+  }
+
+  inject(): void { }
+}

--- a/Client/polyfills/polyfills.ts
+++ b/Client/polyfills/polyfills.ts
@@ -4,19 +4,19 @@
  */
 
 /** IE9, IE10 and IE11 requires all of the following polyfills. **/
-//import 'core-js/es6/symbol';
-//import 'core-js/es6/object';
-//import 'core-js/es6/function';
-//import 'core-js/es6/parse-int';
-//import 'core-js/es6/parse-float';
-//import 'core-js/es6/number';
-//import 'core-js/es6/math';
-//import 'core-js/es6/string';
-//import 'core-js/es6/date';
-//import 'core-js/es6/array';
-//import 'core-js/es6/regexp';
-//import 'core-js/es6/map';
-//import 'core-js/es6/set';
+// import 'core-js/es6/symbol';
+// import 'core-js/es6/object';
+// import 'core-js/es6/function';
+// import 'core-js/es6/parse-int';
+// import 'core-js/es6/parse-float';
+// import 'core-js/es6/number';
+// import 'core-js/es6/math';
+// import 'core-js/es6/string';
+// import 'core-js/es6/date';
+// import 'core-js/es6/array';
+// import 'core-js/es6/regexp';
+// import 'core-js/es6/map';
+// import 'core-js/es6/set';
 
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.

--- a/Client/polyfills/server.polyfills.ts
+++ b/Client/polyfills/server.polyfills.ts
@@ -1,4 +1,4 @@
 ﻿import './polyfills.ts';
 
 import 'reflect-metadata';
-//import 'zone.js';
+import 'zone.js';

--- a/Client/polyfills/temporary-aspnetcore-engine.ts
+++ b/Client/polyfills/temporary-aspnetcore-engine.ts
@@ -1,220 +1,240 @@
-﻿
-/*  ********* TEMPORARILY HERE **************
+﻿/*  ********* TEMPORARILY HERE **************
  * - will be on npm soon -
  *   import { ngAspnetCoreEngine } from `@ng-universal/ng-aspnetcore-engine`;
  */
+import { Type, NgModuleFactory, NgModuleRef, ApplicationRef, Provider, CompilerFactory, Compiler } from '@angular/core';
+import { platformServer, platformDynamicServer, PlatformState, INITIAL_CONFIG, renderModuleFactory } from '@angular/platform-server';
+import { ResourceLoader } from '@angular/compiler';
+import * as fs from 'fs';
 
-import { Type, NgModuleFactory, NgModuleRef, ApplicationRef, Provider } from '@angular/core';
-import { platformServer, platformDynamicServer, PlatformState } from '@angular/platform-server';
+import { REQUEST } from '../app/shared/constants/request';
+import { ORIGIN_URL } from '../app/shared/constants/baseurl.constants';
 
-export function ngAspnetCoreEngine(
-    providers: Provider[],
-    ngModule: Type<{}>
-): Promise<{ html: string, globals: { styles: string, title: string, meta: string, [key: string]: any } }> {
+// import { FileLoader } from './file-loader';
 
-    return new Promise((resolve, reject) => {
-
-        const platform = platformDynamicServer(providers);
-
-        return platform.bootstrapModule(<Type<{}>>ngModule).then((moduleRef: NgModuleRef<{}>) => {
-
-            const state: PlatformState = moduleRef.injector.get(PlatformState);
-            const appRef: ApplicationRef = moduleRef.injector.get(ApplicationRef);
-
-            appRef.isStable
-                .filter((isStable: boolean) => isStable)
-                .first()
-                .subscribe((stable) => {
-
-                    // Fire the TransferCache
-                    const bootstrap = moduleRef.instance['ngOnBootstrap'];
-                    bootstrap && bootstrap();
-
-                    // The parse5 Document itself
-                    const AST_DOCUMENT = state.getDocument();
-
-                    // Strip out the Angular application
-                    const htmlDoc = state.renderToString();
-
-                    const APP_HTML = htmlDoc.substring(
-                        htmlDoc.indexOf('<body>') + 6,
-                        htmlDoc.indexOf('</body>')
-                    );
-
-                    // Strip out Styles / Meta-tags / Title
-                    const STYLES = [];
-                    const META = [];
-                    const LINKS = [];
-                    let TITLE = '';
-
-                    const STYLES_STRING = htmlDoc.substring(
-                        htmlDoc.indexOf('<style ng-transition'),
-                        htmlDoc.lastIndexOf('</style>') + 8
-                    );
-
-                    const HEAD = AST_DOCUMENT.head;
-
-                    let count = 0;
-
-                    for (let i = 0; i < HEAD.children.length; i++) {
-                        let element = HEAD.children[i];
-
-                        if (element.name === 'title') {
-                            TITLE = element.children[0].data;
-                        }
-
-                        // Broken after 4.0 (worked in rc)
-                        // if (element.name === 'style') {
-                        //     let styleTag = '<style ';
-                        //     for (let key in element.attribs) {
-                        //         styleTag += `${key}="${element.attribs[key]}">`;
-                        //     }
-
-                        //     styleTag += `${element.children[0].data}</style>`;
-                        //     STYLES.push(styleTag);
-                        // }
-
-                        if (element.name === 'meta') {
-                            count = count + 1;
-                            let metaString = '<meta';
-                            for (let key in element.attribs) {
-                                metaString += ` ${key}="${element.attribs[key]}"`;
-                            }
-                            META.push(`${metaString} />\n`);
-                        }
-
-                        if (element.name === 'link') {
-                            let linkString = '<link';
-                            for (let key in element.attribs) {
-                                linkString += ` ${key}="${element.attribs[key]}"`;
-                            }
-                            LINKS.push(`${linkString} />\n`);
-                        }
-                    }
-
-                    resolve({
-                        html: APP_HTML,
-                        globals: {
-                            styles: STYLES_STRING,
-                            title: TITLE,
-                            meta: META.join(' '),
-                            links: LINKS.join(' ')
-                        }
-                    });
-
-                    moduleRef.destroy();
-
-                });
-        }).catch(err => {
-            reject(err);
-        });
-
-    });
+export function createTransferScript(transferData: Object): string {
+  return `<script>window['TRANSFER_CACHE'] = ${JSON.stringify(transferData)};</script>`;
 }
 
-// Temporary - these will be combined in what will be the official npm version in `angular/universal` repo
-
-export function ngAspnetCoreEngineAoT(
-    providers: Provider[],
-    ngModule: NgModuleFactory<{}>
-): Promise<{ html: string, globals: { styles: string, title: string, meta: string, [key: string]: any } }> {
-
+export class FileLoader implements ResourceLoader {
+  get(url: string): Promise<string> {
     return new Promise((resolve, reject) => {
+      fs.readFile(url, (err: NodeJS.ErrnoException, buffer: Buffer) => {
+        if (err) {
+          return reject(err);
+        }
 
-        const platform = platformServer(providers);
+        resolve(buffer.toString());
+      });
+    });
+  }
+}
 
-        return platform.bootstrapModuleFactory(ngModule).then((moduleRef: NgModuleRef<{}>) => {
+export interface IRequestParams {
+  location: any;              // e.g., Location object containing information '/some/path'
+  origin: string;             // e.g., 'https://example.com:1234'
+  url: string;                // e.g., '/some/path'
+  baseUrl: string;            // e.g., '' or '/myVirtualDir'
+  absoluteUrl: string;        // e.g., 'https://example.com:1234/some/path'
+  domainTasks: Promise<any>;
+  data: any;                  // any custom object passed through from .NET
+}
+
+export interface IEngineOptions {
+  appSelector: string;
+  request: IRequestParams;
+  ngModule: Type<{}> | NgModuleFactory<{}>;
+  providers?: Provider[];
+};
+
+export function ngAspnetCoreEngine(
+  options: IEngineOptions
+): Promise<{ html: string, globals: { styles: string, title: string, meta: string, transferData?: {}, [key: string]: any } }> {
+
+  options.providers = options.providers || [];
+
+  const compilerFactory: CompilerFactory = platformDynamicServer().injector.get(CompilerFactory);
+  const compiler: Compiler = compilerFactory.createCompiler([
+    {
+      providers: [
+        { provide: ResourceLoader, useClass: FileLoader }
+      ]
+    }
+  ]);
+
+  return new Promise((resolve, reject) => {
+
+    try {
+      const moduleOrFactory = options.ngModule;
+      if (!moduleOrFactory) {
+        throw new Error('You must pass in a NgModule or NgModuleFactory to be bootstrapped');
+      }
+
+      const extraProviders = options.providers.concat(
+        options.providers,
+        [
+          {
+            provide: INITIAL_CONFIG,
+            useValue: {
+              document: options.appSelector,
+              url: options.request.url
+            }
+          },
+          {
+            provide: ORIGIN_URL,
+            useValue: options.request.origin
+          }, {
+            provide: REQUEST,
+            useValue: options.request.data.request
+          }
+        ]
+      );
+
+      const platform = platformServer(extraProviders);
+
+      getFactory(moduleOrFactory, compiler)
+        .then((factory: NgModuleFactory<{}>) => {
+
+          return platform.bootstrapModuleFactory(factory).then((moduleRef: NgModuleRef<{}>) => {
 
             const state: PlatformState = moduleRef.injector.get(PlatformState);
             const appRef: ApplicationRef = moduleRef.injector.get(ApplicationRef);
 
             appRef.isStable
-                .filter((isStable: boolean) => isStable)
-                .first()
-                .subscribe((stable) => {
+              .filter((isStable: boolean) => isStable)
+              .first()
+              .subscribe((stable) => {
 
-                    // Fire the TransferCache
-                    const bootstrap = moduleRef.instance['ngOnBootstrap'];
-                    bootstrap && bootstrap();
+                // Fire the TransferState Cache
+                const bootstrap = moduleRef.instance['ngOnBootstrap'];
+                bootstrap && bootstrap();
 
-                    // The parse5 Document itself
-                    const AST_DOCUMENT = state.getDocument();
+                // The parse5 Document itself
+                const AST_DOCUMENT = state.getDocument();
 
-                    // Strip out the Angular application
-                    const htmlDoc = state.renderToString();
+                // Strip out the Angular application
+                const htmlDoc = state.renderToString();
 
-                    const APP_HTML = htmlDoc.substring(
-                        htmlDoc.indexOf('<body>') + 6,
-                        htmlDoc.indexOf('</body>')
-                    );
+                const APP_HTML = htmlDoc.substring(
+                  htmlDoc.indexOf('<body>') + 6,
+                  htmlDoc.indexOf('</body>')
+                );
 
-                    // Strip out Styles / Meta-tags / Title
-                    const STYLES = [];
-                    const META = [];
-                    const LINKS = [];
-                    let TITLE = '';
+                // Strip out Styles / Meta-tags / Title
+                const STYLES = [];
+                const META = [];
+                const LINKS = [];
+                let TITLE = '';
 
-                    const STYLES_STRING = htmlDoc.substring(
-                        htmlDoc.indexOf('<style ng-transition'),
-                        htmlDoc.lastIndexOf('</style>') + 8
-                    );
+                let STYLES_STRING = htmlDoc.substring(
+                  htmlDoc.indexOf('<style ng-transition'),
+                  htmlDoc.lastIndexOf('</style>') + 8
+                );
+                // STYLES_STRING = STYLES_STRING.replace(/\s/g, '').replace('<styleng-transition', '<style ng-transition');
 
-                    const HEAD = AST_DOCUMENT.head;
+                const HEAD = AST_DOCUMENT.head;
 
-                    let count = 0;
+                let count = 0;
 
-                    for (let i = 0; i < HEAD.children.length; i++) {
-                        let element = HEAD.children[i];
+                for (let i = 0; i < HEAD.children.length; i++) {
+                  let element = HEAD.children[i];
 
-                        if (element.name === 'title') {
-                            TITLE = element.children[0].data;
-                        }
+                  if (element.name === 'title') {
+                    TITLE = element.children[0].data;
+                  }
 
-                        // Broken after 4.0 (worked in rc)
-                        // if (element.name === 'style') {
-                        //     let styleTag = '<style ';
-                        //     for (let key in element.attribs) {
-                        //         styleTag += `${key}="${element.attribs[key]}">`;
-                        //     }
+                  // Broken after 4.0 (worked in rc)
+                  // if (element.name === 'style') {
+                  //   let styleTag = '<style ';
+                  //   for (let key in element.attribs) {
+                  //     if (key) {
+                  //       styleTag += `${key}="${element.attribs[key]}">`;
+                  //     }
+                  //   }
 
-                        //     styleTag += `${element.children[0].data}</style>`;
-                        //     STYLES.push(styleTag);
-                        // }
+                  //   styleTag += `${element.children[0].data}</style>`;
+                  //   STYLES.push(styleTag);
+                  // }
 
-                        if (element.name === 'meta') {
-                            count = count + 1;
-                            let metaString = '<meta';
-                            for (let key in element.attribs) {
-                                metaString += ` ${key}="${element.attribs[key]}"`;
-                            }
-                            META.push(`${metaString} />\n`);
-                        }
-
-                        if (element.name === 'link') {
-                            let linkString = '<link';
-                            for (let key in element.attribs) {
-                                linkString += ` ${key}="${element.attribs[key]}"`;
-                            }
-                            LINKS.push(`${linkString} />\n`);
-                        }
+                  if (element.name === 'meta') {
+                    count = count + 1;
+                    let metaString = '<meta';
+                    for (let key in element.attribs) {
+                      if (key) {
+                        metaString += ` ${key}="${element.attribs[key]}"`;
+                      }
                     }
+                    META.push(`${metaString} />\n`);
+                  }
 
-                    resolve({
-                        html: APP_HTML,
-                        globals: {
-                            styles: STYLES_STRING,
-                            title: TITLE,
-                            meta: META.join(' '),
-                            links: LINKS.join(' ')
-                        }
-                    });
+                  if (element.name === 'link') {
+                    let linkString = '<link';
+                    for (let key in element.attribs) {
+                      if (key) {
+                        linkString += ` ${key}="${element.attribs[key]}"`;
+                      }
+                    }
+                    LINKS.push(`${linkString} />\n`);
+                  }
+                }
 
-                    moduleRef.destroy();
-
+                resolve({
+                  html: APP_HTML,
+                  globals: {
+                    styles: STYLES_STRING,
+                    title: TITLE,
+                    meta: META.join(' '),
+                    links: LINKS.join(' ')
+                  }
                 });
-        }).catch(err => {
-            reject(err);
+
+                moduleRef.destroy();
+
+              }, (err) => {
+                reject(err);
+              });
+
+          });
         });
 
-    });
+    } catch (ex) {
+      reject(ex);
+    }
+
+  });
+}
+
+/* ********************** Private / Internal ****************** */
+
+const factoryCacheMap = new Map<Type<{}>, NgModuleFactory<{}>>();
+function getFactory(
+  moduleOrFactory: Type<{}> | NgModuleFactory<{}>, compiler: Compiler
+): Promise<NgModuleFactory<{}>> {
+  return new Promise<NgModuleFactory<{}>>((resolve, reject) => {
+    // If module has been compiled AoT
+    if (moduleOrFactory instanceof NgModuleFactory) {
+      console.log('Already AoT?');
+      resolve(moduleOrFactory);
+      return;
+    } else {
+      let moduleFactory = factoryCacheMap.get(moduleOrFactory);
+
+      // If module factory is cached
+      if (moduleFactory) {
+        console.log('\n\n\n WE FOUND ONE!! USE IT!!\n\n\n');
+        resolve(moduleFactory);
+        return;
+      }
+
+      // Compile the module and cache it
+      compiler.compileModuleAsync(moduleOrFactory)
+        .then((factory) => {
+          console.log('\n\n\n\n MAP THIS THING!!!!\n\n\n ');
+          factoryCacheMap.set(moduleOrFactory, factory);
+          resolve(factory);
+        }, (err => {
+          reject(err);
+        }));
+    }
+  });
 }

--- a/Server/Controllers/HomeController.cs
+++ b/Server/Controllers/HomeController.cs
@@ -6,6 +6,9 @@ using Microsoft.AspNetCore.NodeServices;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http.Features;
+using Microsoft.AspNetCore.Http;
+using System.Diagnostics;
+using System;
 
 namespace AspCoreServer.Controllers
 {
@@ -21,6 +24,15 @@ namespace AspCoreServer.Controllers
             var unencodedPathAndQuery = requestFeature.RawTarget;
             var unencodedAbsoluteUrl = $"{Request.Scheme}://{Request.Host}{unencodedPathAndQuery}";
 
+            // ** TransferData concept **
+            // Here we can pass any Custom Data we want !
+
+            // By default we're passing down Cookies, Headers, Host from the Request object here
+            TransferData transferData = new TransferData();
+            transferData.request = AbstractHttpContextRequestInfo(Request);
+            transferData.thisCameFromDotNET = "Hi Angular it's asp.net :)";
+            // Add more customData here, add it to the TransferData class
+
             // Prerender / Serialize application (with Universal)
             var prerenderResult = await Prerenderer.RenderToString(
                 "/",
@@ -28,16 +40,17 @@ namespace AspCoreServer.Controllers
                 new JavaScriptModuleExport(applicationBasePath + "/Client/dist/main-server"),
                 unencodedAbsoluteUrl,
                 unencodedPathAndQuery,
-                null,
+                transferData, // Our simplified Request object & any other CustommData you want to send!
                 30000,
                 Request.PathBase.ToString()
             );
 
-            ViewData["SpaHtml"] = prerenderResult.Html;
-            ViewData["Title"] = prerenderResult.Globals["title"];
-            ViewData["Styles"] = prerenderResult.Globals["styles"];
-            ViewData["Meta"] = prerenderResult.Globals["meta"];
-            ViewData["Links"] = prerenderResult.Globals["links"];
+            ViewData["SpaHtml"] = prerenderResult.Html; // our <app> from Angular
+            ViewData["Title"] = prerenderResult.Globals["title"]; // set our <title> from Angular
+            ViewData["Styles"] = prerenderResult.Globals["styles"]; // put styles in the correct place
+            ViewData["Meta"] = prerenderResult.Globals["meta"]; // set our <meta> SEO tags
+            ViewData["Links"] = prerenderResult.Globals["links"]; // set our <link rel="canonical"> etc SEO tags
+            ViewData["TransferData"] = prerenderResult.Globals["transferData"]; // our transfer data set to window.TRANSFER_CACHE = {};
 
             return View();
         }
@@ -46,5 +59,31 @@ namespace AspCoreServer.Controllers
         {
             return View();
         }
+
+        private IRequest AbstractHttpContextRequestInfo(HttpRequest request)
+        {
+
+            IRequest requestSimplified = new IRequest();
+            requestSimplified.cookies = request.Cookies;
+            requestSimplified.headers = request.Headers;
+            requestSimplified.host = request.Host;
+
+            return requestSimplified;
+        }
+    }
+
+    public class IRequest
+    {
+        public object cookies { get; set; }
+        public object headers { get; set; }
+        public object host { get; set; }
+    }
+
+    public class TransferData
+    {
+        public dynamic request { get; set; }
+
+        // Your data here ?
+        public object thisCameFromDotNET { get; set; }
     }
 }

--- a/Views/Home/Index.cshtml
+++ b/Views/Home/Index.cshtml
@@ -1,6 +1,8 @@
 ﻿@Html.Raw(ViewData["SpaHtml"])
 
 @*<script src="~/dist/vendor.js" asp-append-version="true"></script>*@
+
 @section scripts {
+    <!-- Our webpack bundle -->
     <script src="~/dist/main-browser.js" asp-append-version="true"></script>
 }

--- a/Views/Shared/_Layout.cshtml
+++ b/Views/Shared/_Layout.cshtml
@@ -8,7 +8,7 @@
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         @Html.Raw(ViewData["Meta"])
         @Html.Raw(ViewData["Links"])
-        
+
         <link rel="stylesheet" href="~/dist/vendor.css" asp-append-version="true" />
 
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/flag-icon-css/0.8.2/css/flag-icon.min.css" />
@@ -25,6 +25,9 @@
                 crossorigin="anonymous"></script>
 
         <script src="http://ajax.aspnetcdn.com/ajax/signalr/jquery.signalr-2.2.0.min.js"></script>
+
+        <!-- Here we're passing down any data to be used by grabbed and parsed by Angular -->
+        @Html.Raw(ViewData["TransferData"])
 
         @RenderSection("scripts", required: false)
     </body>

--- a/boot-tests.ts
+++ b/boot-tests.ts
@@ -1,7 +1,6 @@
 // Load required polyfills and testing libraries
 import '../polyfills/server.polyfills';
 
-import 'angular2-universal-polyfills';
 import 'zone.js/dist/long-stack-trace-zone';
 import 'zone.js/dist/proxy.js';
 import 'zone.js/dist/sync-test';


### PR DESCRIPTION
- Major bug fixes
- Update engine (publishing to Npm soon, will be removed from project shortly)
  - Engine will be at `@ng-universal/aspnetcore-engine` soon.
  - Engine now auto compiles JIT to AoT, only does AoT rendering, if JIT is provided it will compile it and try to save it in a cache to be reused in later cycles. For Prod it will already have everything AoT compiled so it will skip that step automatically.
  - Engine also features a `createTransferScript` that will create the window TRANSFER_STATE that will automatically get pulled down and reused.
  - Only use HttpTransfer for GETs that are CRUCIAL during a pageload, ones you don't want "flickering" and being re-ran on the Client side.
- Added HttpTransfer mechanism
- Added REQUEST injectionToken (soon will be part of engine)

Fixes #170 #169