### PR TITLE
Ignore dist folders in IDE and clear them on MSBuild clean

### DIFF
--- a/Asp2017.csproj
+++ b/Asp2017.csproj
@@ -17,6 +17,8 @@
   <ItemGroup>
     <!-- Files not to show in IDE -->
     <None Remove="yarn.lock" />
+	<Content Remove="wwwroot\dist\**" />
+	<None Remove="Client\dist\**" />
 
     <!-- Files not to publish (note that the 'dist' subfolders are re-added below) -->
     <Content Remove="Client\**" />
@@ -39,5 +41,12 @@
         <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
       </ResolvedFileToPublish>
     </ItemGroup>
+  </Target>
+  <Target Name="CleanDist" AfterTargets="Clean">
+    <ItemGroup>
+      <FilesToDelete Include="Client\dist\**; wwwroot\dist\**"/>
+    </ItemGroup>
+    <Delete Files="@(FilesToDelete)" />
+    <RemoveDir Directories="Client\dist; wwwroot\dist" />
   </Target>
 </Project>


### PR DESCRIPTION
Just a little quality of life thing.

By keeping the `dist` folder out of the project, the navigate to functionality is faster and it keeps VS from thrashing on webpack rebuilds.