### PR TITLE
Issue #78 Updates typescript to 2.3.2, adds vs code launch configs

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,73 +1,118 @@
 {
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "name": "[Development] Launch Web",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.1/Asp2017.dll",
-            "args": [],
-            "cwd": "${workspaceRoot}",
-            "stopAtEntry": false,
-            "internalConsoleOptions": "openOnSessionStart",
-            "launchBrowser": {
-                "enabled": true,
-                "args": "${auto-detect-url}",
-                "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                },
-                "osx": {
-                    "command": "open"
-                },
-                "linux": {
-                    "command": "xdg-open"
-                }
-            },
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Development"
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceRoot}/Views"
-            }
+  "version": "0.2.0",
+  "compounds": [{
+    "name": "[Development] Debug Server & Client",
+    "configurations": ["[Development] Launch Server (no browser)", "[Development] Debug TypeScript"]
+  }],
+  "configurations": [{
+
+      "name": "[Development] Debug TypeScript",
+      "type": "chrome",
+      "request": "launch",
+      "url": "http://localhost:5000",
+      "webRoot": "${workspaceRoot}/wwwroot",
+      "sourceMapPathOverrides": {
+        "webpack:///./*": "${workspaceRoot}\\*"
+      }
+    },
+    {
+      "name": "[Development] Launch Server (no browser)",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceRoot}/bin/Debug/netcoreapp1.1/Asp2017.dll",
+      "args": [],
+      "cwd": "${workspaceRoot}",
+      "stopAtEntry": false,
+      "internalConsoleOptions": "openOnSessionStart",
+      "launchBrowser": {
+        "enabled": false,
+        "args": "${auto-detect-url}",
+        "windows": {
+          "command": "cmd.exe",
+          "args": "/C start ${auto-detect-url}"
         },
-        {
-            "name": "[Production] Launch Web",
-            "type": "coreclr",
-            "request": "launch",
-            "preLaunchTask": "build",
-            "program": "${workspaceRoot}/bin/Debug/netcoreapp1.1/Asp2017.dll",
-            "args": [],
-            "cwd": "${workspaceRoot}",
-            "stopAtEntry": false,
-            "internalConsoleOptions": "openOnSessionStart",
-            "launchBrowser": {
-                "enabled": true,
-                "args": "${auto-detect-url}",
-                "windows": {
-                    "command": "cmd.exe",
-                    "args": "/C start ${auto-detect-url}"
-                },
-                "osx": {
-                    "command": "open"
-                },
-                "linux": {
-                    "command": "xdg-open"
-                }
-            },
-            "env": {
-                "ASPNETCORE_ENVIRONMENT": "Production"
-            },
-            "sourceFileMap": {
-                "/Views": "${workspaceRoot}/src/AspCoreServer/Views"
-            }
+        "osx": {
+          "command": "open"
         },
-        {
-            "name": ".NET Core Attach",
-            "type": "coreclr",
-            "request": "attach",
-            "processId": "${command:pickProcess}"
+        "linux": {
+          "command": "xdg-open"
         }
-    ]
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceRoot}/Views"
+      }
+    },
+    {
+      "name": "[Development] Launch Web",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceRoot}/bin/Debug/netcoreapp1.1/Asp2017.dll",
+      "args": [],
+      "cwd": "${workspaceRoot}",
+      "stopAtEntry": false,
+      "internalConsoleOptions": "openOnSessionStart",
+      "launchBrowser": {
+        "enabled": true,
+        "args": "${auto-detect-url}",
+        "windows": {
+          "command": "cmd.exe",
+          "args": "/C start ${auto-detect-url}"
+        },
+        "osx": {
+          "command": "open"
+        },
+        "linux": {
+          "command": "xdg-open"
+        }
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceRoot}/Views"
+      }
+    },
+    {
+      "name": "[Production] Launch Web",
+      "type": "coreclr",
+      "request": "launch",
+      "preLaunchTask": "build",
+      "program": "${workspaceRoot}/bin/Debug/netcoreapp1.1/Asp2017.dll",
+      "args": [],
+      "cwd": "${workspaceRoot}",
+      "stopAtEntry": false,
+      "internalConsoleOptions": "openOnSessionStart",
+      "launchBrowser": {
+        "enabled": true,
+        "args": "${auto-detect-url}",
+        "windows": {
+          "command": "cmd.exe",
+          "args": "/C start ${auto-detect-url}"
+        },
+        "osx": {
+          "command": "open"
+        },
+        "linux": {
+          "command": "xdg-open"
+        }
+      },
+      "env": {
+        "ASPNETCORE_ENVIRONMENT": "Production"
+      },
+      "sourceFileMap": {
+        "/Views": "${workspaceRoot}/src/AspCoreServer/Views"
+      }
+    },
+    {
+      "name": ".NET Core Attach",
+      "type": "coreclr",
+      "request": "attach",
+      "processId": "${command:pickProcess}"
+    }
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "signalr": "^2.2.1",
     "style-loader": "^0.13.1",
     "to-string-loader": "^1.1.5",
-    "typescript": "^2.2.1",
+    "typescript": "^2.3.2",
     "url-loader": "^0.5.7",
     "webpack": "^2.2.0",
     "webpack-hot-middleware": "^2.12.2",


### PR DESCRIPTION
# Overview

This adds two new launch configs and a compound config for debugging the client typescript.

There is a LOT going on with VS Code right now, and there has been a lot of instability in general around both .NET core and Typescript debugging. Make sure your C# extension is up to date, and if you have trouble consider [installing a pre-release](https://github.com/OmniSharp/omnisharp-vscode/wiki/Installing-Beta-Releases) if one is available.

Either way though, the debugging experience when you try to mix typescript and .net core debugging is fairly rough right now, but a lot of effort is going into making that work much smoother over the next few months.

# launch configs

"[Development] Debug TypeScript" launches a browser for debugging via the chrome debug extensions. Assumes the server is already running. The key here seems to be specifying the sourceMapPathOverrides setting instead of letting it use the default paths.

_needs testing with linux / osx; I'm not sure the sourceMapPathOverrides is quite right for other OSes._

"[Development] Launch Server (no browser)" launches the asp.net core server, but does not open a browser. Intended for use with multi-target debugging in VS Code. Pretty much the same as the existing one, just doesn't open a browser automatically

"[Development] Debug Server & Client" this is a compound debugger configuration that starts both of the above configurations in parallel. 

# Start multi-target debugging manually:

- In VS Code, select the "[Development] Launch Server (no browser)" config and start debugging.
- Wait until the server has had a few seconds to spin up
- Switch VS Code to the "[Development] Debug TypeScript" configuration and start debugging

The debug bar in VS Code will show two debugger configs and give you a drop down to switch between them. You can set breakpoints for server or client code.

# Using the compound config

The "[Development] Debug Server & Client" config starts debuggers for both the server and client configs at the same time. This is not the smoothest experience since the client config will try to open the browser before the server process is running. Keep refreshing the browser window and it should bring up the page as soon as the server is online.