### PR TITLE
Fixed error 500 on requesting swagger.json

### DIFF
--- a/Server/Controllers/HomeController.cs
+++ b/Server/Controllers/HomeController.cs
@@ -14,6 +14,7 @@ namespace AspCoreServer.Controllers
 {
     public class HomeController : Controller
     {
+        [HttpGet] 
         public async Task<IActionResult> Index()
         {
             var nodeServices = Request.HttpContext.RequestServices.GetRequiredService<INodeServices>();
@@ -55,6 +56,7 @@ namespace AspCoreServer.Controllers
             return View();
         }
 
+        [HttpGet] 
         [Route("sitemap.xml")]
         public async Task<IActionResult> SitemapXml()
         {


### PR DESCRIPTION
This fixes #310. 
Error 500 was occurring on requesting swagger.json (http://localhost:5000/swagger/v1/swagger.json) under the following conditions:
 - Pulled the project "as is" from GitHub
 - The environment is set to Development (as per this post)
 - Launch the project (F5)
 - Swagger UI gets loaded (http://localhost:5000/swagger/)

See Swagger's requirements on method attributes in the comment here - https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/69#issuecomment-245347034