### PR TITLE
Change to emit 'wwwroot/dist' folder on MSBUILD

### DIFF
--- a/Asp2017.csproj
+++ b/Asp2017.csproj
@@ -23,6 +23,20 @@
     <!-- Files not to publish (note that the 'dist' subfolders are re-added below) -->
     <Content Remove="ClientApp\**" />
   </ItemGroup>
+  <Target Name="DebugRunWebpack" BeforeTargets="Build" Condition=" '$(Configuration)' == 'Debug' And !Exists('wwwroot\dist') ">
+    <!-- Ensure Node.js is installed -->
+    <Exec Command="node --version" ContinueOnError="true">
+      <Output TaskParameter="ExitCode" PropertyName="ErrorCode" />
+    </Exec>
+    <Error Condition="'$(ErrorCode)' != '0'" Text="Node.js is required to build and run this project. To continue, please install Node.js from https://nodejs.org/, and then restart your command prompt or IDE." />
+
+    <!-- In development, the dist files won't exist on the first run or when cloning to
+         a different machine, so rebuild them if not already present. -->
+    <Message Importance="high" Text="Performing first-run Webpack build..." />
+    <Exec Command="npm install" />
+    <Exec Command="node node_modules/webpack/bin/webpack.js --config webpack.config.vendor.js" />
+    <Exec Command="node node_modules/webpack/bin/webpack.js" />
+  </Target>
   <Target Name="RunWebpack" AfterTargets="ComputeFilesToPublish">
     <!-- As part of publishing, ensure the JS resources are freshly built in production mode -->
     <Exec Command="npm install" />


### PR DESCRIPTION
This PR is based on the .csproj file present in JavascriptServices project.

It validates and shows message when Node is not installed in the system.
It runs webpack build script before MSBuild project, Only IF there is no 'www/dist' folder created.
Helpful for first time project build after fresh clone OR after clean solution.

This also avoids the extra step mentioned in Readme
> Note: If you get any errors after this such as module not found: boot.server (or similar), open up command line and run npm run build:dev to make sure all the assets have been properly built by Webpack.