### PR TITLE
Update Asp2017.csproj to delete correct dist directory

### DIFF
--- a/Asp2017.csproj
+++ b/Asp2017.csproj
@@ -57,6 +57,6 @@
       <FilesToDelete Include="ClientApp\dist\**; wwwroot\dist\**" />
     </ItemGroup>
     <Delete Files="@(FilesToDelete)" />
-    <RemoveDir Directories="Client\dist; wwwroot\dist" />
+    <RemoveDir Directories="ClientApp\dist; wwwroot\dist" />
   </Target>
 </Project>


### PR DESCRIPTION
The 'Client' folder does not exist, so the 'ClientApp' folder should be removed instead.