### PR TITLE
fix(polyfills): move reflect-metadata to polyfills.ts

### DIFF
--- a/ClientApp/polyfills/browser.polyfills.ts
+++ b/ClientApp/polyfills/browser.polyfills.ts
@@ -1,4 +1,3 @@
 import './polyfills.ts';
 
 import 'zone.js/dist/zone';
-import 'reflect-metadata';

--- a/ClientApp/polyfills/polyfills.ts
+++ b/ClientApp/polyfills/polyfills.ts
@@ -18,6 +18,9 @@
  import 'core-js/es6/map';
  import 'core-js/es6/set';
 
+ /** */
+ import 'reflect-metadata';
+
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 

--- a/ClientApp/polyfills/server.polyfills.ts
+++ b/ClientApp/polyfills/server.polyfills.ts
@@ -1,4 +1,3 @@
 ﻿import './polyfills.ts';
 
-import 'reflect-metadata';
 import 'zone.js';


### PR DESCRIPTION
No need to have it in both browser.polyfills.ts and server.polyfills.ts when it's the same.

Closes #580