### PR TITLE
fix(polyfills): web-animations-js should be in browser.polyfills.ts

### DIFF
--- a/ClientApp/polyfills/browser.polyfills.ts
+++ b/ClientApp/polyfills/browser.polyfills.ts
@@ -2,3 +2,4 @@ import './polyfills.ts';
 
 import 'zone.js/dist/zone';
 import 'reflect-metadata';
+// import 'web-animations-js';  // Run `npm install --save web-animations-js`.

--- a/ClientApp/polyfills/polyfills.ts
+++ b/ClientApp/polyfills/polyfills.ts
@@ -21,8 +21,6 @@
 /** IE10 and IE11 requires the following for NgClass support on SVG elements */
 // import 'classlist.js';  // Run `npm install --save classlist.js`.
 
-// import 'web-animations-js';  // Run `npm install --save web-animations-js`.
-
 /** Evergreen browsers require these. **/
 import 'core-js/es6/reflect';
 import 'core-js/es7/reflect';


### PR DESCRIPTION
Since `web-animations-js` uses `document` it really shouldn't be imported in `polyfills.ts` but in `browser.polyfills.ts`