### PR TITLE
Fix cache busting

### DIFF
--- a/Views/_ViewImports.cshtml
+++ b/Views/_ViewImports.cshtml
@@ -1,2 +1,3 @@
 @using AspCoreServer
 @addTagHelper "*, Microsoft.AspNetCore.SpaServices"
+@addTagHelper "*, Microsoft.AspNetCore.Mvc.TagHelpers"


### PR DESCRIPTION
This fix makes the cache busting work. When using asp-append-version="true" in Index.cshtml like this:
<script src="~/dist/vendor.js" asp-append-version="true"></script>

It will turn that into:

<script src="~/dist/vendor.js?v=37182361827361" ></script>

When you publish.