### PR TITLE
Better fix for StaticInjectorError

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,138 +16,161 @@ const CheckerPlugin = require('awesome-typescript-loader').CheckerPlugin;
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
-const { sharedModuleRules } = require('./webpack.additions');
+const {
+  sharedModuleRules
+} = require('./webpack.additions');
 
 module.exports = (env) => {
-    // Configuration in common to both client-side and server-side bundles
-    const isDevBuild = !(env && env.prod);
-    const sharedConfig = {
-        mode: isDevBuild ? "development" : "production",
-        stats: { modules: false },
+  // Configuration in common to both client-side and server-side bundles
+  const isDevBuild = !(env && env.prod);
+  const sharedConfig = {
+    mode: isDevBuild ? "development" : "production",
+    stats: {
+      modules: false
+    },
+    context: __dirname,
+    resolve: {
+      extensions: ['.js', '.ts']
+    },
+    output: {
+      filename: '[name].js',
+      publicPath: 'dist/' // Webpack dev middleware, if enabled, handles requests for this URL prefix
+    },
+    module: {
+      rules: [{
+          test: /\.ts$/,
+          use: isDevBuild ? ['awesome-typescript-loader?silent=true', 'angular2-template-loader', 'angular2-router-loader'] : '@ngtools/webpack'
+        },
+        {
+          test: /\.html$/,
+          use: 'html-loader?minimize=false'
+        },
+        {
+          test: /\.css$/,
+          use: ['to-string-loader', isDevBuild ? 'css-loader' : 'css-loader?minimize']
+        },
+        {
+          test: /\.(png|jpg|jpeg|gif|svg)$/,
+          use: 'url-loader?limit=25000'
+        },
+        ...sharedModuleRules
+      ]
+    },
+    plugins: [new CheckerPlugin()]
+  };
+
+  // Configuration for client-side bundle suitable for running in browsers
+  const clientBundleOutputDir = './wwwroot/dist';
+  const clientBundleConfig = merge(sharedConfig, {
+    entry: {
+      'main-client': './ClientApp/boot.browser.ts'
+    },
+    output: {
+      path: path.join(__dirname, clientBundleOutputDir)
+    },
+    plugins: [
+      new webpack.DllReferencePlugin({
         context: __dirname,
-        resolve: { extensions: [ '.js', '.ts' ] },
-        output: {
-            filename: '[name].js',
-            publicPath: 'dist/' // Webpack dev middleware, if enabled, handles requests for this URL prefix
-        },
-        module: {
-            rules: [
-                { test: /\.ts$/, use: isDevBuild ? ['awesome-typescript-loader?silent=true', 'angular2-template-loader', 'angular2-router-loader'] : '@ngtools/webpack' },
-                { test: /\.html$/, use: 'html-loader?minimize=false' },
-                { test: /\.css$/, use: [ 'to-string-loader', isDevBuild ? 'css-loader' : 'css-loader?minimize' ] },
-                { test: /\.(png|jpg|jpeg|gif|svg)$/, use: 'url-loader?limit=25000' },
-                ...sharedModuleRules
-            ]
-        },
-        plugins: [new CheckerPlugin()]
-    };
+        manifest: require('./wwwroot/dist/vendor-manifest.json')
+      })
+    ].concat(isDevBuild ? [
+      // Plugins that apply in development builds only
+      new webpack.SourceMapDevToolPlugin({
+        filename: '[file].map', // Remove this line if you prefer inline source maps
+        moduleFilenameTemplate: path.relative(clientBundleOutputDir, '[resourcePath]') // Point sourcemap entries to the original file locations on disk
+      })
+    ] : [
+      // new BundleAnalyzerPlugin(),
+      // Plugins that apply in production builds only
+      new AngularCompilerPlugin({
+        mainPath: path.join(__dirname, 'ClientApp/boot.browser.ts'),
+        tsConfigPath: './tsconfig.json',
+        entryModule: path.join(__dirname, 'ClientApp/app/app.module.browser#AppModule'),
+        exclude: ['./**/*.server.ts']
+      })
+    ]),
+    devtool: isDevBuild ? 'cheap-eval-source-map' : false,
+    node: {
+      fs: "empty"
+    },
+    optimization: {
+      minimizer: [].concat(isDevBuild ? [] : [
+        // we specify a custom UglifyJsPlugin here to get source maps in production
+        new UglifyJsPlugin({
+          cache: true,
+          parallel: true,
+          uglifyOptions: {
+            compress: false,
+            ecma: 6,
+            mangle: true,
+            keep_classnames: true,
+            keep_fnames: true
+          },
+          sourceMap: true
+        })
+      ])
+    }
+  });
 
-    // Configuration for client-side bundle suitable for running in browsers
-    const clientBundleOutputDir = './wwwroot/dist';
-    const clientBundleConfig = merge(sharedConfig, {
-        entry: { 'main-client': './ClientApp/boot.browser.ts' },
-        output: { path: path.join(__dirname, clientBundleOutputDir) },
-        plugins: [
-            new webpack.DllReferencePlugin({
-                context: __dirname,
-                manifest: require('./wwwroot/dist/vendor-manifest.json')
-            })
-        ].concat(isDevBuild ? [
-            // Plugins that apply in development builds only
-            new webpack.SourceMapDevToolPlugin({
-                filename: '[file].map', // Remove this line if you prefer inline source maps
-                moduleFilenameTemplate: path.relative(clientBundleOutputDir, '[resourcePath]') // Point sourcemap entries to the original file locations on disk
-            })
-        ] : [
-            // new BundleAnalyzerPlugin(),
-            // Plugins that apply in production builds only
-            new AngularCompilerPlugin({
-              mainPath: path.join(__dirname, 'ClientApp/boot.browser.ts'),
-              tsConfigPath: './tsconfig.json',
-              entryModule: path.join(__dirname, 'ClientApp/app/app.module.browser#AppModule'),
-              exclude: ['./**/*.server.ts']
-            })
-          ]),
-        devtool: isDevBuild ? 'cheap-eval-source-map' : false,
-        node: {
-          fs: "empty"
-        },
-        optimization: {
-          minimizer: [].concat(isDevBuild ? [] : [
-            // we specify a custom UglifyJsPlugin here to get source maps in production
-            new UglifyJsPlugin({
-              cache: true,
-              parallel: true,
-              uglifyOptions: {
-                compress: false,
-                ecma: 6,
-                mangle: true
-              },
-              sourceMap: true
-            })
-          ])
-        }
-    });
+  // Configuration for server-side (prerendering) bundle suitable for running in Node
+  const serverBundleConfig = merge(sharedConfig, {
+    // resolve: { mainFields: ['main'] },
+    entry: {
+      'main-server': isDevBuild ? './ClientApp/boot.server.ts' : './ClientApp/boot.server.PRODUCTION.ts'
+    },
+    plugins: [
+      new webpack.DllReferencePlugin({
+        context: __dirname,
+        manifest: require('./ClientApp/dist/vendor-manifest.json'),
+        sourceType: 'commonjs2',
+        name: './vendor'
+      })
+    ].concat(isDevBuild ? [
+      new webpack.ContextReplacementPlugin(
+        // fixes WARNING Critical dependency: the request of a dependency is an expression
+        /(.+)?angular(\\|\/)core(.+)?/,
+        path.join(__dirname, 'src'), // location of your src
+        {} // a map of your routes
+      ),
+      new webpack.ContextReplacementPlugin(
+        // fixes WARNING Critical dependency: the request of a dependency is an expression
+        /(.+)?express(\\|\/)(.+)?/,
+        path.join(__dirname, 'src'), {}
+      )
+    ] : [
+      // Plugins that apply in production builds only
+      new AngularCompilerPlugin({
+        mainPath: path.join(__dirname, 'ClientApp/boot.server.PRODUCTION.ts'),
+        tsConfigPath: './tsconfig.json',
+        entryModule: path.join(__dirname, 'ClientApp/app/app.module.server#AppModule'),
+        exclude: ['./**/*.browser.ts']
+      })
+    ]),
+    output: {
+      libraryTarget: 'commonjs',
+      path: path.join(__dirname, './ClientApp/dist')
+    },
+    target: 'node',
+    // switch to "inline-source-map" if you want to debug the TS during SSR
+    devtool: isDevBuild ? 'cheap-eval-source-map' : false,
+    optimization: {
+      minimizer: [].concat(isDevBuild ? [] : [
+        // we specify a custom UglifyJsPlugin here to get source maps in production
+        new UglifyJsPlugin({
+          cache: true,
+          parallel: true,
+          uglifyOptions: {
+            compress: false,
+            ecma: 6,
+            mangle: true,
+            keep_classnames: true,
+            keep_fnames: true
+          },
+          sourceMap: true
+        })
+      ])
+    }
+  });
 
-    // Configuration for server-side (prerendering) bundle suitable for running in Node
-    const serverBundleConfig = merge(sharedConfig, {
-        // resolve: { mainFields: ['main'] },
-        entry: {
-          'main-server':
-          isDevBuild ? './ClientApp/boot.server.ts' : './ClientApp/boot.server.PRODUCTION.ts'
-        },
-        plugins: [
-            new webpack.DllReferencePlugin({
-                context: __dirname,
-                manifest: require('./ClientApp/dist/vendor-manifest.json'),
-                sourceType: 'commonjs2',
-                name: './vendor'
-            })
-        ].concat(isDevBuild ? [
-            new webpack.ContextReplacementPlugin(
-              // fixes WARNING Critical dependency: the request of a dependency is an expression
-              /(.+)?angular(\\|\/)core(.+)?/,
-              path.join(__dirname, 'src'), // location of your src
-              {} // a map of your routes
-            ),
-            new webpack.ContextReplacementPlugin(
-              // fixes WARNING Critical dependency: the request of a dependency is an expression
-              /(.+)?express(\\|\/)(.+)?/,
-              path.join(__dirname, 'src'),
-              {}
-            )
-        ] : [
-            // Plugins that apply in production builds only
-            new AngularCompilerPlugin({
-              mainPath: path.join(__dirname, 'ClientApp/boot.server.PRODUCTION.ts'),
-              tsConfigPath: './tsconfig.json',
-              entryModule: path.join(__dirname, 'ClientApp/app/app.module.server#AppModule'),
-              exclude: ['./**/*.browser.ts']
-            })
-        ]),
-        output: {
-            libraryTarget: 'commonjs',
-            path: path.join(__dirname, './ClientApp/dist')
-        },
-        target: 'node',
-        // switch to "inline-source-map" if you want to debug the TS during SSR
-        devtool: isDevBuild ? 'cheap-eval-source-map' : false,
-        optimization: {
-          minimizer: [].concat(isDevBuild ? [] : [
-            // we specify a custom UglifyJsPlugin here to get source maps in production
-            new UglifyJsPlugin({
-              cache: true,
-              parallel: true,
-              uglifyOptions: {
-                compress: false,
-                ecma: 6,
-                mangle: true
-              },
-              sourceMap: true
-            })
-          ])
-        }
-    });
-
-    return [clientBundleConfig, serverBundleConfig];
+  return [clientBundleConfig, serverBundleConfig];
 };

--- a/webpack.config.vendor.js
+++ b/webpack.config.vendor.js
@@ -4,128 +4,148 @@ const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const merge = require('webpack-merge');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const treeShakableModules = [
-    '@angular/animations',
-    '@angular/common',
-    '@angular/compiler',
-    '@angular/core',
-    '@angular/forms',
-    '@angular/http',
-    '@angular/platform-browser',
-    '@angular/platform-browser-dynamic',
-    '@angular/router',
-    'ngx-bootstrap',
-    'zone.js',
+  '@angular/animations',
+  '@angular/common',
+  '@angular/compiler',
+  '@angular/core',
+  '@angular/forms',
+  '@angular/http',
+  '@angular/platform-browser',
+  '@angular/platform-browser-dynamic',
+  '@angular/router',
+  'ngx-bootstrap',
+  'zone.js',
 ];
 const nonTreeShakableModules = [
-    // 'bootstrap',
-    // 'bootstrap/dist/css/bootstrap.css',
-    'core-js',
-    // 'es6-promise',
-    // 'es6-shim',
-    'event-source-polyfill',
-    // 'jquery',
+  // 'bootstrap',
+  // 'bootstrap/dist/css/bootstrap.css',
+  'core-js',
+  // 'es6-promise',
+  // 'es6-shim',
+  'event-source-polyfill',
+  // 'jquery',
 ];
 
 const allModules = treeShakableModules.concat(nonTreeShakableModules);
 
 module.exports = (env) => {
-    console.log(`env = ${JSON.stringify(env)}`)
-    const extractCSS = new ExtractTextPlugin('vendor.css');
-    const isDevBuild = !(env && env.prod);
-    const sharedConfig = {
-        mode: isDevBuild ? "development" : "production",
-        stats: { modules: false },
-        resolve: { extensions: [ '.js' ] },
-        module: {
-            rules: [
-                { test: /\.(png|woff|woff2|eot|ttf|svg)(\?|$)/, use: 'url-loader?limit=100000' }
-            ]
-        },
-        output: {
-            publicPath: 'dist/',
-            filename: '[name].js',
-            library: '[name]_[hash]'
-        },
-        plugins: [
-            // new webpack.ProvidePlugin({ $: 'jquery', jQuery: 'jquery' }), // Maps these identifiers to the jQuery package (because Bootstrap expects it to be a global variable)
-            new webpack.ContextReplacementPlugin(/\@angular\b.*\b(bundles|linker)/, path.join(__dirname, './ClientApp')), // Workaround for https://github.com/angular/angular/issues/11580
-            new webpack.ContextReplacementPlugin(/(.+)?angular(\\|\/)core(.+)?/, path.join(__dirname, './ClientApp')), // Workaround for https://github.com/angular/angular/issues/14898
-            new webpack.IgnorePlugin(/^vertx$/) // Workaround for https://github.com/stefanpenner/es6-promise/issues/100
-        ]
-    };
+  console.log(`env = ${JSON.stringify(env)}`)
+  const extractCSS = new ExtractTextPlugin('vendor.css');
+  const isDevBuild = !(env && env.prod);
+  const sharedConfig = {
+    mode: isDevBuild ? "development" : "production",
+    stats: {
+      modules: false
+    },
+    resolve: {
+      extensions: ['.js']
+    },
+    module: {
+      rules: [{
+        test: /\.(png|woff|woff2|eot|ttf|svg)(\?|$)/,
+        use: 'url-loader?limit=100000'
+      }]
+    },
+    output: {
+      publicPath: 'dist/',
+      filename: '[name].js',
+      library: '[name]_[hash]'
+    },
+    plugins: [
+      // new webpack.ProvidePlugin({ $: 'jquery', jQuery: 'jquery' }), // Maps these identifiers to the jQuery package (because Bootstrap expects it to be a global variable)
+      new webpack.ContextReplacementPlugin(/\@angular\b.*\b(bundles|linker)/, path.join(__dirname, './ClientApp')), // Workaround for https://github.com/angular/angular/issues/11580
+      new webpack.ContextReplacementPlugin(/(.+)?angular(\\|\/)core(.+)?/, path.join(__dirname, './ClientApp')), // Workaround for https://github.com/angular/angular/issues/14898
+      new webpack.IgnorePlugin(/^vertx$/) // Workaround for https://github.com/stefanpenner/es6-promise/issues/100
+    ]
+  };
 
-    const clientBundleConfig = merge(sharedConfig, {
-        entry: {
-            // To keep development builds fast, include all vendor dependencies in the vendor bundle.
-            // But for production builds, leave the tree-shakable ones out so the AOT compiler can produce a smaller bundle.
-            vendor: isDevBuild ? allModules : nonTreeShakableModules
-        },
-        output: { path: path.join(__dirname, 'wwwroot', 'dist') },
-        module: {
-            rules: [
-                { test: /\.css(\?|$)/, use: extractCSS.extract({ use: isDevBuild ? 'css-loader' : 'css-loader?minimize' }) }
-            ]
-        },
-        plugins: [
-            extractCSS,
-            new webpack.DllPlugin({
-                path: path.join(__dirname, 'wwwroot', 'dist', '[name]-manifest.json'),
-                name: '[name]_[hash]'
-            })
-        ].concat(isDevBuild ? [] : [
+  const clientBundleConfig = merge(sharedConfig, {
+    entry: {
+      // To keep development builds fast, include all vendor dependencies in the vendor bundle.
+      // But for production builds, leave the tree-shakable ones out so the AOT compiler can produce a smaller bundle.
+      vendor: isDevBuild ? allModules : nonTreeShakableModules
+    },
+    output: {
+      path: path.join(__dirname, 'wwwroot', 'dist')
+    },
+    module: {
+      rules: [{
+        test: /\.css(\?|$)/,
+        use: extractCSS.extract({
+          use: isDevBuild ? 'css-loader' : 'css-loader?minimize'
+        })
+      }]
+    },
+    plugins: [
+      extractCSS,
+      new webpack.DllPlugin({
+        path: path.join(__dirname, 'wwwroot', 'dist', '[name]-manifest.json'),
+        name: '[name]_[hash]'
+      })
+    ].concat(isDevBuild ? [] : [
 
-        ]),
-        optimization: {
-          minimizer: [].concat(isDevBuild ? [] : [
-            // we specify a custom UglifyJsPlugin here to get source maps in production
-            new UglifyJsPlugin({
-              cache: true,
-              parallel: true,
-              uglifyOptions: {
-                compress: false,
-                ecma: 6,
-                mangle: true
-              },
-              sourceMap: true
-            })
-          ])
-        }
-    });
+    ]),
+    optimization: {
+      minimizer: [].concat(isDevBuild ? [] : [
+        // we specify a custom UglifyJsPlugin here to get source maps in production
+        new UglifyJsPlugin({
+          cache: true,
+          parallel: true,
+          uglifyOptions: {
+            compress: false,
+            ecma: 6,
+            mangle: true,
+            keep_classnames: true,
+            keep_fnames: true
+          },
+          sourceMap: true
+        })
+      ])
+    }
+  });
 
-    const serverBundleConfig = merge(sharedConfig, {
-        target: 'node',
-        resolve: { mainFields: ['main'] },
-        entry: { vendor: allModules.concat(['aspnet-prerendering']) },
-        output: {
-            path: path.join(__dirname, 'ClientApp', 'dist'),
-            libraryTarget: 'commonjs2',
-        },
-        module: {
-            rules: [ { test: /\.css(\?|$)/, use: ['to-string-loader', isDevBuild ? 'css-loader' : 'css-loader?minimize' ] } ]
-        },
-        plugins: [
-            new webpack.DllPlugin({
-                path: path.join(__dirname, 'ClientApp', 'dist', '[name]-manifest.json'),
-                name: '[name]_[hash]'
-            })
-        ].concat(isDevBuild ? [] : [
-        ]),
-        optimization: {
-          minimizer: [].concat(isDevBuild ? [] : [
-            // we specify a custom UglifyJsPlugin here to get source maps in production
-            new UglifyJsPlugin({
-              cache: true,
-              parallel: true,
-              uglifyOptions: {
-                compress: false,
-                ecma: 6,
-                mangle: true
-              },
-              sourceMap: true
-            })
-          ])
-        }
-    });
+  const serverBundleConfig = merge(sharedConfig, {
+    target: 'node',
+    resolve: {
+      mainFields: ['main']
+    },
+    entry: {
+      vendor: allModules.concat(['aspnet-prerendering'])
+    },
+    output: {
+      path: path.join(__dirname, 'ClientApp', 'dist'),
+      libraryTarget: 'commonjs2',
+    },
+    module: {
+      rules: [{
+        test: /\.css(\?|$)/,
+        use: ['to-string-loader', isDevBuild ? 'css-loader' : 'css-loader?minimize']
+      }]
+    },
+    plugins: [
+      new webpack.DllPlugin({
+        path: path.join(__dirname, 'ClientApp', 'dist', '[name]-manifest.json'),
+        name: '[name]_[hash]'
+      })
+    ].concat(isDevBuild ? [] : []),
+    optimization: {
+      minimizer: [].concat(isDevBuild ? [] : [
+        // we specify a custom UglifyJsPlugin here to get source maps in production
+        new UglifyJsPlugin({
+          cache: true,
+          parallel: true,
+          uglifyOptions: {
+            compress: false,
+            ecma: 6,
+            mangle: true,
+            keep_classnames: true,
+            keep_fnames: true
+          },
+          sourceMap: true
+        })
+      ])
+    }
+  });
 
-    return [clientBundleConfig, serverBundleConfig];
+  return [clientBundleConfig, serverBundleConfig];
 }


### PR DESCRIPTION
The problem with SSR is known issue for angular applications, https://github.com/angular/angular-cli/issues/8616
The fix is to ensure class names are kept with the mangle. This is a better solution than turning mangle off.