### PR TITLE
Update .csproj to reflect changes in .NET Core 2.1

### DIFF
--- a/Asp2017.csproj
+++ b/Asp2017.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
   <ItemGroup>
     <!-- New Meta Package has SpaServices in It -->
-    <PackageReference Include="Microsoft.AspNetCore.All" Version="2.1.0" />
+    <PackageReference Include="Microsoft.AspNetCore.All" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="0.1.1646902" />
     <PackageReference Include="NETStandard.Library" Version="2.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.0" />


### PR DESCRIPTION
I have removed the version identifier for the ASP.NET meta package in accordance to the changes in .NET Core.

[Here](https://docs.microsoft.com/en-us/aspnet/core/migration/20_21?view=aspnetcore-2.1#rules-for-projects-targeting-the-shared-runtime) is the description of what changed and why the version has to be removed.

I ran into [#7969](https://github.com/aspnet/Mvc/issues/7969) and was able to "fix" it this way.