### PR TITLE
upgraded to angular-router-loader for proper angular 6 code splitting…

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,11 @@ module.exports = (env) => {
     module: {
       rules: [{
           test: /\.ts$/,
-          use: isDevBuild ? ['awesome-typescript-loader?silent=true', 'angular2-template-loader', 'angular2-router-loader'] : '@ngtools/webpack'
+          use: ['awesome-typescript-loader?silent=true', 'angular2-template-loader']
+        },
+        {
+          test: /\.(ts|js)$/,
+          use: 'angular-router-loader'
         },
         {
           test: /\.html$/,


### PR DESCRIPTION
… and lazy loading support

The prior approach with the older angular2-router-loader does not work anymore. We had to upgrade to the recommended angular-router-loader (see https://www.npmjs.com/package/angular-router-loader) and modify this webpack file accordingly. Works much better for us. In production, @ngtools/webpack  does not work for us, and the proposed changes have been verified in prod and are stable.

This requires the other change adding replacing the package in package.json